### PR TITLE
No need to specify $TMPDIR, let mktemp automatically determine

### DIFF
--- a/src/shared/functions/filesystem-temp.sh
+++ b/src/shared/functions/filesystem-temp.sh
@@ -3,7 +3,7 @@ function createTempFileDirectoryIfNecessary {
 	then
 		local base=$(basename "$JQNPM_SOURCE")
 
-		echo -nE $(mktemp -d "${TMPDIR:-TMP}${base}.XXXXXX")
+		echo -nE $(mktemp -d "${base}.XXXXXX")
 	fi
 }
 

--- a/tests/create-bundles.sh
+++ b/tests/create-bundles.sh
@@ -24,7 +24,7 @@ function createTempFileDirectoryIfNecessary {
 	then
 		local base=$(basename "$BASH_SOURCE")
 
-		internalTmpDir=$(mktemp -d "${TMPDIR:-TMP}${base}.XXXXXX")
+		internalTmpDir=$(mktemp -d "${base}.XXXXXX")
 	fi
 }
 


### PR DESCRIPTION
No need to specify `$TMPDIR`, let `mktemp` automatically determine temp directory.

This is problematic because on some platforms it is defined or undefined. Also missing slash.

I tested on Windows, Linux.
On Windows, I use Bash (come from git for windows 2.6). `$TMPDIR` is automatically set
On Linux, I use Bash. `$TMPDIR` is unset.