### PR TITLE
Add travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: xenial    # use Ubuntu 16.04 base image
+language: bash
+
+before_install:
+  - sudo apt-get install -y shunit2
+
+script:
+  - jq --version
+  - ./tests/all.sh


### PR DESCRIPTION
Adding Travis support to run the test script(s). By @nichtich.

Tests currently do not fail, unless the last test fails. Exit codes should be collected and reported at the end of the script.